### PR TITLE
Visual improvements for job cards: shadows, borders, spacing, skill tags

### DIFF
--- a/src/app/experience/experience.component.css
+++ b/src/app/experience/experience.component.css
@@ -8,11 +8,17 @@
 .card {
   backdrop-filter: blur(10px);
   transition: all 0.3s ease;
+  box-shadow:
+  inset 1px 1px 8px rgba(0, 0, 0, 0.25),
+  0 4px 15px rgba(0, 0, 0, 0.3);  
 }
 
 .card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.2);
+  box-shadow:
+  inset 1px 1px 8px rgba(0, 0, 0, 0.25),
+  0 20px 25px -5px rgba(0, 0, 0, 0.3),
+  0 10px 10px -5px rgba(0, 0, 0, 0.2);
 }
 
 .skill-tag {

--- a/src/app/experience/experience.component.html
+++ b/src/app/experience/experience.component.html
@@ -42,11 +42,11 @@
           <!-- desktop card (left side) -->
           <div class="w-full md:w-1/2 pr-8 text-left hidden md:block">
             <div
-              class="card relative inline-block border border-white/20 bg-slate-800 md:bg-slate-800/80 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
+              class="card relative inline-block border border-white/25 bg-slate-800 md:bg-slate-800/90 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
               data-aos="fade-right">
               <!-- toggle button -->
               <button (click)="toggleDetails(0)"
-                class="absolute top-4 right-4 text-blue-300 border-2 border-sky-300/50 w-10 h-10 rounded-full flex items-center justify-center hover:bg-sky-400/10 hover:border-sky-400/70 transition-all duration-300 hover:scale-110 group"
+                class="absolute top-4 right-4 text-blue-300 border border-sky-300/50 w-10 h-10 rounded-full flex items-center justify-center hover:bg-sky-400/10 hover:border-sky-400/70 transition-all duration-300 hover:scale-110 group"
                 aria-label="Toggle details" title="Toggle details">
 
                 <!-- plus icon with rotate on hover -->
@@ -73,7 +73,7 @@
 
               <!-- toggle for details -->
               <div *ngIf="showDetails[0]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-sky-400 mr-2">•</span>
                     Built and maintained Angular applications with modern best practices
@@ -90,13 +90,13 @@
               </div>
 
               <!-- skill tags -->
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Software Development
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Software Architecture
                 </span>
               </div>
@@ -106,7 +106,7 @@
           <!-- mobile card -->
           <div class="w-full md:hidden pl-8">
             <div
-              class="card relative bg-slate-800 md:bg-slate-800/80 border border-white/20 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
+              class="card relative bg-slate-800 md:bg-slate-800/90 border border-white/25 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
               data-aos="fade-left">
               <!-- mobile toggle button -->
               <button (click)="toggleDetails(0)"
@@ -135,7 +135,7 @@
 
               <!-- toggle for details -->
               <div *ngIf="showDetails[0]">
-                <ul class="space-y-5 mb-6 pl-4 text-gray-300">
+                <ul class="space-y-5 mt-4 mb-8 pl-4 text-gray-300">
                   <li class="flex items-start">
                     <span class="text-sky-400 mr-2">•</span>
                     Built and maintained Angular applications with modern best practices
@@ -151,13 +151,13 @@
                 </ul>
               </div>
 
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-xs font-semibold rounded-full">Software
-                  Development</span>
+                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 md:mb-0">
+                  Software Development</span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-xs font-semibold rounded-full">Software
-                  Architecture</span>
+                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
+                  Software Architecture</span>
               </div>
             </div>
           </div>
@@ -176,8 +176,8 @@
 
           <div class="w-full md:w-1/2 pl-8">
             <div
-              class="card relative bg-slate-800 md:bg-slate-800/80 border border-white/20 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-emerald-400/30"
-              data-aos="fade-left">
+              class="card relative bg-slate-800 md:bg-slate-800/90 border border-white/25 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-emerald-400/30"
+              data-aos="fade-left"> <!-- border-white/20 -->
 
               <!-- toggle button -->
               <button (click)="toggleDetails(1)"
@@ -208,7 +208,7 @@
 
               <!-- toggled details -->
               <div *ngIf="showDetails[1]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-emerald-400 mr-2">•</span>
                     Conducted comprehensive functional testing across mobile and web platforms
@@ -225,13 +225,13 @@
               </div>
 
               <!-- skill tags -->
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-emerald-500/20 to-emerald-600/20 text-emerald-300 border border-emerald-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-emerald-500/20 to-emerald-600/20 text-emerald-300 border border-emerald-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 mr-1 md:mb-0">
                   Test
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 md:mb-0">
                   Business Analysis
                 </span>
               </div>
@@ -251,7 +251,7 @@
           <!-- desktop left side card -->
           <div class="w-full md:w-1/2 pr-8 text-left hidden md:block">
             <div
-              class="card relative inline-block border border-white/20 bg-slate-800 md:bg-slate-800/80 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-cyan-400/30"
+              class="card relative inline-block border border-white/25 bg-slate-800 md:bg-slate-800/90 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-cyan-400/30"
               data-aos="fade-right">
 
               <!-- toggle button -->
@@ -282,7 +282,7 @@
 
               <!-- details toggled -->
               <div *ngIf="showDetails[2]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-cyan-400 mr-2">•</span>
                     Designed application architecture and system workflows
@@ -299,13 +299,13 @@
               </div>
 
               <!-- skill tags -->
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Software Architecture
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Business Analysis
                 </span>
               </div>
@@ -315,7 +315,7 @@
           <!-- mobile card -->
           <div class="w-full md:hidden pl-8">
             <div
-              class="card relative bg-slate-800 md:bg-slate-800/80 border border-white/20 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-cyan-400/30"
+              class="card relative bg-slate-800 md:bg-slate-800/90 border border-white/25 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-cyan-400/30"
               data-aos="fade-left">
 
               <!-- mobile toggle button -->
@@ -345,7 +345,7 @@
 
               <!-- details toggled mobile -->
               <div *ngIf="showDetails[2]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-cyan-400 mr-2">•</span>
                     Designed application architecture and system workflows
@@ -361,13 +361,13 @@
                 </ul>
               </div>
 
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-cyan-500/20 to-cyan-600/20 text-cyan-300 border border-cyan-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 md:mb-0">
                   Software Architecture
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Business Analysis
                 </span>
               </div>
@@ -388,7 +388,7 @@
 
           <div class="w-full md:w-1/2 pl-8">
             <div
-              class="card relative bg-slate-800 md:bg-slate-800/80 border border-white/20 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-emerald-400/30"
+              class="card relative bg-slate-800 md:bg-slate-800/90 border border-white/25 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-emerald-400/30"
               data-aos="fade-left">
 
               <!-- toggle button -->
@@ -420,7 +420,7 @@
 
               <!-- details -->
               <div *ngIf="showDetails[3]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-emerald-400 mr-2">•</span>
                     Designed and implemented automated testing frameworks
@@ -437,13 +437,13 @@
               </div>
 
               <!-- skill tags -->
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-emerald-500/20 to-emerald-600/20 text-emerald-300 border border-emerald-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-emerald-500/20 to-emerald-600/20 text-emerald-300 border border-emerald-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 mr-1 md:mb-0">
                   Test
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-violet-500/20 to-violet-600/20 text-violet-300 border border-violet-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-violet-500/20 to-violet-600/20 text-violet-300 border border-violet-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 md:mb-0">
                   Consulting
                 </span>
               </div>
@@ -463,7 +463,7 @@
         <div class="relative flex items-start fade-in" style="animation-delay: 0.5s;">
           <div class="w-full md:w-1/2 pr-8 text-left hidden md:block">
             <div
-              class="card relative inline-block border border-white/20 bg-slate-800 md:bg-slate-800/80 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
+              class="card relative inline-block border border-white/25 bg-slate-800 md:bg-slate-800/90 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
               data-aos="fade-right">
 
               <!-- toggle button -->
@@ -492,7 +492,7 @@
 
               <!-- details -->
               <div *ngIf="showDetails[4]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-sky-400 mr-2">•</span>
                     Developed enterprise Java applications using Spring framework
@@ -509,13 +509,13 @@
               </div>
 
               <!-- skill tags -->
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Software Development
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Business Analysis
                 </span>
               </div>
@@ -525,7 +525,7 @@
           <!-- mobile card -->
           <div class="w-full md:hidden pl-8">
             <div
-              class="card relative bg-slate-800 md:bg-slate-800/80 border border-white/20 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
+              class="card relative bg-slate-800 md:bg-slate-800/90 border border-white/25 p-6 rounded-xl shadow-xl text-white w-full max-w-md hover:border-sky-400/30"
               data-aos="fade-left">
 
               <!-- toggle button -->
@@ -555,7 +555,7 @@
               </div>
 
               <div *ngIf="showDetails[4]">
-                <ul class="space-y-5 mb-6 pl-4">
+                <ul class="space-y-5 mt-4 mb-8 pl-4">
                   <li class="text-gray-300 flex items-start">
                     <span class="text-sky-400 mr-2">•</span>
                     Developed enterprise Java applications using Spring framework
@@ -571,13 +571,13 @@
                 </ul>
               </div>
 
-              <div class="flex flex-wrap gap-2 mt-4">
+              <div class="flex flex-wrap gap-2 mt-6">
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-sky-500/20 to-sky-600/20 text-sky-300 border border-sky-400/30 px-3 py-1 text-[13px] font-normal rounded-full mb-1 md:mb-0">
                   Software Development
                 </span>
                 <span
-                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-xs font-semibold rounded-full">
+                  class="skill-tag inline-block bg-gradient-to-r from-indigo-500/20 to-indigo-600/20 text-indigo-300 border border-indigo-400/30 px-3 py-1 text-[13px] font-normal rounded-full">
                   Business Analysis
                 </span>
               </div>


### PR DESCRIPTION
- Add subtle inner box-shadow to cards for better depth
- Ensure hover shadow effect keeps inner shadow intact
- Refine border opacity (using 25% white) for clearer but subtle card edges
- Improve spacing for skill tags (pills) on mobile with margin-bottom on wrap
- Adjust background opacity on desktop cards for better visibility