### PR TITLE
Fix: use native fetch in Node.js, remove node-fetch

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const path = require('path');
 const { DateTime } = require('luxon');
-const fetch = require('node-fetch');
 
 const app = express();
 


### PR DESCRIPTION
- Resolve issue caused by missing module, ensuring dyno wake-up pings work as intended
- Verify server-side ping wakes Heroku dynos without errors